### PR TITLE
add ?ACTION=add_uri to PAUSE upload URI

### DIFF
--- a/lib/CPAN/Upload/Tiny.pm
+++ b/lib/CPAN/Upload/Tiny.pm
@@ -9,7 +9,7 @@ use MIME::Base64 ();
 use HTTP::Tiny;
 use HTTP::Tiny::Multipart;
 
-my $UPLOAD_URI = $ENV{CPAN_UPLOADER_UPLOAD_URI} || 'https://pause.perl.org/pause/authenquery';
+my $UPLOAD_URI = $ENV{CPAN_UPLOADER_UPLOAD_URI} || 'https://pause.perl.org/pause/authenquery?ACTION=add_uri';
 
 sub new {
 	my ($class, $user, $password) = @_;


### PR DESCRIPTION
PAUSE used to accept uploads without `?ACTION=add_uri`, but it should be added.
In fact, if people upload files via PAUSE web page, then they post the files to PAUSE URI with `?ACTION=add_uri`.

This PR adds `?ACTION=add_uri` to PAUSE upload URI.
cc @charsbar

Note:
* PAUSE on Mojolicious has special handling for cpan-uploaders https://github.com/andk/pause/pull/266/commits/f51e2e2f492ca9fc135305d62b5a434e468c6303,
so cpan-upload-tiny works as it is. But I think it is nice to use PAUSE URI with `?ACTION=add_uri`.
* CPAN-Uploader now also uses PAUSE URI with ACTION https://github.com/rjbs/CPAN-Uploader/commit/91240187563a7a7f4d90efb1d9fb65d5e75737ab